### PR TITLE
A1 - Add bare run.sh to create a docker container that is runnable in HA

### DIFF
--- a/hassio-java-addon/Dockerfile
+++ b/hassio-java-addon/Dockerfile
@@ -1,4 +1,8 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
 
-CMD [ "echo \"Hello world!\"" ]
+COPY run.sh /
+
+RUN chmod a+x /run.sh
+
+CMD [ "/run.sh" ]

--- a/hassio-java-addon/run.sh
+++ b/hassio-java-addon/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "Hello world!"


### PR DESCRIPTION
The `run.sh` file is actually required as well due to this error:
<pre>s6-overlay-suexec: fatal: can only run as pid 1</pre>